### PR TITLE
YSMOD-187 Nytt endepunkt for å hente kodeverk som liste (i tillegg til...

### DIFF
--- a/src/main/kotlin/no/nav/yrkesskade/kodeverk/controller/v1/KodeverkController.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/kodeverk/controller/v1/KodeverkController.kt
@@ -27,11 +27,20 @@ class KodeverkController(val kodeverkService: KodeverkService) {
     }
 
     @GetMapping("/typer/{typenavn}/kategorier/{kategorinavn}/kodeverdier")
-    fun hentKodeverdiForTypeOgKategori(
+    fun hentMapMedKodeverdierForTypeOgKategori(
         @PathVariable("typenavn") typenavn: String,
         @PathVariable("kategorinavn") kategorinavn: String
     ): ResponseEntity<KodeverdiResponsDto> {
         val kodeverdier = kodeverkService.hentKodeverdiForTypeOgKategori(typenavn, kategorinavn)
-        return ResponseEntity.ok(KodeverdiResponsDto(kodeverdier))
+        return ResponseEntity.ok(KodeverdiResponsDto.tilRespons(kodeverdier))
+    }
+
+    @GetMapping("/typer/{typenavn}/kategorier/{kategorinavn}/kodeverdierliste")
+    fun hentListeMedKodeverdierForTypeOgKategori(
+        @PathVariable("typenavn") typenavn: String,
+        @PathVariable("kategorinavn") kategorinavn: String
+    ): ResponseEntity<KodeverdiListeResponsDto> {
+        val kodeverdier = kodeverkService.hentKodeverdiForTypeOgKategori(typenavn, kategorinavn)
+        return ResponseEntity.ok(KodeverdiListeResponsDto(kodeverdier))
     }
 }

--- a/src/main/kotlin/no/nav/yrkesskade/kodeverk/controller/v1/dto/KodeverdiDto.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/kodeverk/controller/v1/dto/KodeverdiDto.kt
@@ -4,24 +4,23 @@ import no.nav.yrkesskade.kodeverk.oppslag.kodeverk.api.Betydning
 import no.nav.yrkesskade.kodeverk.oppslag.kodeverk.api.GetKodeverkKoderBetydningerResponse
 import no.nav.yrkesskade.kodeverk.repository.Verdi
 
-data class KodeverdiDto(val kode: String, val spraak: String, val verdi: String, val sortering: Int?) {
+data class KodeverdiDto(val kode: String, val verdi: String) {
 
     companion object {
-        fun konverter(verdi: Verdi): KodeverdiDto = KodeverdiDto(verdi.getKode(), verdi.getSpraak(), verdi.getVerdi(), verdi.getSortering())
+        fun konverter(verdi: Verdi): KodeverdiDto = KodeverdiDto(verdi.getKode(), verdi.getVerdi())
 
-        fun fromKoderBetydningerResponse(response: GetKodeverkKoderBetydningerResponse): Map<KodeStreng, KodeverdiDto> {
+        fun fromKoderBetydningerResponse(response: GetKodeverkKoderBetydningerResponse): List<KodeverdiDto> {
             return response.betydninger
                 .entries
                 .map { Kodemapper(it.key, it.value) }
                 .let { koder -> fromBetydninger(koder) }
-                .associateBy { it.kode }
         }
 
        private fun fromBetydninger(koder: List<Kodemapper>): List<KodeverdiDto> {
             return koder.flatMap {
                 it.betydninger.flatMap { betydning ->
                     betydning.beskrivelser.entries.map { beskrivelse ->
-                        KodeverdiDto(it.kode, beskrivelse.key, beskrivelse.value.tekst!!, null)
+                        KodeverdiDto(it.kode, beskrivelse.value.tekst!!)
                     }
                 }
             }

--- a/src/main/kotlin/no/nav/yrkesskade/kodeverk/controller/v1/dto/KodeverdiListeResponsDto.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/kodeverk/controller/v1/dto/KodeverdiListeResponsDto.kt
@@ -1,0 +1,5 @@
+package no.nav.yrkesskade.kodeverk.controller.v1.dto
+
+data class KodeverdiListeResponsDto(
+    var kodeverdierListe: List<KodeverdiDto> = mutableListOf()
+)

--- a/src/main/kotlin/no/nav/yrkesskade/kodeverk/controller/v1/dto/KodeverdiResponsDto.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/kodeverk/controller/v1/dto/KodeverdiResponsDto.kt
@@ -2,4 +2,12 @@ package no.nav.yrkesskade.kodeverk.controller.v1.dto
 
 data class KodeverdiResponsDto (
     var kodeverdierMap: Map<KodeStreng, KodeverdiDto> = mutableMapOf()
-)
+) {
+    companion object {
+        fun tilRespons(kodeverdierListe: List<KodeverdiDto>): KodeverdiResponsDto =
+            KodeverdiResponsDto(tilMap(kodeverdierListe))
+
+        private fun tilMap(kodeverdierListe: List<KodeverdiDto>): Map<KodeStreng, KodeverdiDto> =
+            kodeverdierListe.associateBy { it.kode }
+    }
+}

--- a/src/main/kotlin/no/nav/yrkesskade/kodeverk/oppslag/kodeverk/KodeverkClient.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/kodeverk/oppslag/kodeverk/KodeverkClient.kt
@@ -33,7 +33,7 @@ class KodeverkClient(
     private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
 
     @Cacheable
-    fun hentKodeverkVerdier(eksternNavn: String): Map<KodeStreng, KodeverdiDto> {
+    fun hentKodeverkVerdier(eksternNavn: String): List<KodeverdiDto> {
         return hentKodeverkBetydning(eksternNavn, ekskluderUgyldige = true)
     }
 
@@ -50,7 +50,7 @@ class KodeverkClient(
     }
 
     @Suppress("SameParameterValue")
-    private fun hentKodeverkBetydning(navn: String, ekskluderUgyldige: Boolean): Map<KodeStreng, KodeverdiDto> {
+    private fun hentKodeverkBetydning(navn: String, ekskluderUgyldige: Boolean): List<KodeverdiDto> {
         buildRequest("api/v1/kodeverk/$navn/koder/betydninger", ekskluderUgyldige).get().use { response ->
             val responseBody = response.readEntity(String::class.java)
             if (SUCCESSFUL != response.statusInfo.family) {

--- a/src/main/kotlin/no/nav/yrkesskade/kodeverk/service/KodeverkService.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/kodeverk/service/KodeverkService.kt
@@ -24,7 +24,7 @@ class KodeverkService(
 
     fun hentKodetyper(): List<KodetypeDto> = kodetypeRepository.findAll().map { KodetypeDto.konverter(it) }
 
-    fun hentKodeverdiForTypeOgKategori(typenavn: String, kategorinavn: String): Map<KodeStreng, KodeverdiDto> {
+    fun hentKodeverdiForTypeOgKategori(typenavn: String, kategorinavn: String): List<KodeverdiDto> {
         val example: Example<Kodetype> = Example.of(Kodetype(null, typenavn, null, null, null, null))
         val kodetype = kodetypeRepository.findOne(example).orElseThrow {
             ManglendeDataException("Kunne ikke hente kodeverdier for type $typenavn og kategori $kategorinavn. Fant ingen kodetype med navn $typenavn!")
@@ -42,7 +42,6 @@ class KodeverkService(
         return kodeverdiRepository
             .hentKodeverdiForTypeOgKategori(kodetype.typeId!!, kodekategori.kategoriId!!)
             .map { kodeverdi -> KodeverdiDto.konverter(kodeverdi) }
-            .associateBy { it.kode }
     }
 
     fun hentKategorierForType(typenavn: String): List<KodekategoriDto> {

--- a/src/test/kotlin/no/nav/yrkesskade/kodeverk/controller/v1/KodeverkControllerIT.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/kodeverk/controller/v1/KodeverkControllerIT.kt
@@ -2,6 +2,7 @@ package no.nav.yrkesskade.kodeverk.controller.v1
 
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import no.nav.yrkesskade.kodeverk.controller.v1.dto.KodeverdiListeResponsDto
 import no.nav.yrkesskade.kodeverk.controller.v1.dto.KodeverdiResponsDto
 import no.nav.yrkesskade.kodeverk.test.AbstractIT
 import no.nav.yrkesskade.kodeverk.test.TestMockServerInitialization
@@ -42,13 +43,30 @@ class KodeverkControllerIT : AbstractIT() {
     }
 
     @Test
-    fun `hent kodeverk verdier for tidsrom og elev kategori`() {
+    fun `hent map med kodeverk verdier for tidsrom og elev kategori`() {
         mvc.perform(
             get("$KODEVERK_V1/typer/tidsrom/kategorier/elev/kodeverdier")
         ).andExpect(status().isOk)
             .andExpect(jsonPath("$.kodeverdierMap").isMap)
             .andExpect(jsonPath("$.kodeverdierMap.length()").value(9))
 
+    }
+
+    @Test
+    fun `hent liste med kodeverk verdier for tidsrom og elev kategori`() {
+        val resultActions = mvc.perform(
+            get("$KODEVERK_V1/typer/tidsrom/kategorier/elev/kodeverdierliste")
+        ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.kodeverdierListe").isArray)
+            .andExpect(jsonPath("$.kodeverdierListe.length()").value(9))
+
+        val json = resultActions.andReturn().response.contentAsString
+        val responsDto = objectMapper.readValue(json, KodeverdiListeResponsDto::class.java)
+        val kodeverdierListe = responsDto.kodeverdierListe
+        assertThat(kodeverdierListe.size).isEqualTo(9)
+        val elementA = kodeverdierListe[0]
+        val elementB = kodeverdierListe[1]
+        assertThat(elementA.verdi).isLessThan(elementB.verdi) // sortert alfabetisk på verdi
     }
 
     @Test
@@ -65,9 +83,7 @@ class KodeverkControllerIT : AbstractIT() {
 
         val iAvtaltArbeidstid = kodeverdierMap["iAvtaltArbeidstid"]
         assertThat(iAvtaltArbeidstid?.kode).isEqualTo("iAvtaltArbeidstid")
-        assertThat(iAvtaltArbeidstid?.spraak).isEqualTo("nb")
         assertThat(iAvtaltArbeidstid?.verdi).isEqualTo("I avtalt arbeidstid")
-        assertThat(iAvtaltArbeidstid?.sortering).isEqualTo(0)
     }
 
     /**
@@ -96,7 +112,6 @@ class KodeverkControllerIT : AbstractIT() {
 
         val norge = kodeverdierMap["NOR"]
         assertThat(norge?.kode).isEqualTo("NOR")
-        assertThat(norge?.spraak).isEqualTo("nb")
         assertThat(norge?.verdi).isEqualTo("NORGE")
     }
 


### PR DESCRIPTION
… endepunkt som returnerer map)

-----
Ref slack-dialog fra fredag fra https://nav-it.slack.com/archives/C02TAUL9Z5X/p1648813275179699 og videre...

(noen utklipp):

Hmmm, vi gjorde om respons fra kodeverk fra lister til map for en tid siden. For noen bruksområder er det praktisk, som f.eks. oppslag på landkode. Nedtrekkslistene i fontend derimot ville hatt bedre nytte av (ferdig sorterte) lister.
[...]
>Some implementations do also preserve the order of JSON objects as well, but this is not guaranteed.

Virker som om det kommer an på implementasjonen av json-bibliotekene, og at vi ikke har noen garanti for at det blir riktig.
[...]
lister i json beholder rekkefølgen, så det er fordelen med å bytte til liste
[...]
men hvis de samme kodelistene skal brukes av eksterne ved innsending via eksternt api, tenker jeg at det er best om at det er så enkelt som mulig. dvs kun koder og verdier, og ferdig sortert.